### PR TITLE
fix: исправлена директива @namespace

### DIFF
--- a/meta/metadata.txt
+++ b/meta/metadata.txt
@@ -9,7 +9,7 @@
 <% _.forEach(pkg.contributors, function (contributor) { %>
 @contributor <%= contributor.name %><%= contributor.email ? ` <${contributor.email}> ` : "" %><%= contributor.url ? ` ${contributor.url}` : "" %>
 <% }) %>
-@namespace <%= pkg.homepage %>
+@namespace __github__
 @homepage <%= pkg.homepage %>
 @supportURL <%= pkg.bugs.url %>
 @updateURL __github__/raw/master/vklistadd.user.js


### PR DESCRIPTION
В старой версии юзерскрипта использовался namespace со ссылкой на этот репозиторий без якоря. Чтобы обновить скрипт на Greasefork нужно исправить эту директиву.