### PR TITLE
fix: неправильные надписи для флажков

### DIFF
--- a/src/components/lists/ListRow.tsx
+++ b/src/components/lists/ListRow.tsx
@@ -55,6 +55,7 @@ export function ListRow({ list, disabled }: IListRowProps) {
 				text={list.name}
 				onChange={onChange}
 				disabled={disabled}
+				id={`list${list.id}`}
 			/>
 
 			<EditListButton list={list} />

--- a/src/components/vk/CheckboxRow.tsx
+++ b/src/components/vk/CheckboxRow.tsx
@@ -1,6 +1,6 @@
 import { h } from "preact";
 import { toStyleCombiner } from "@utils/fashion";
-import { useState, useCallback, useEffect } from "preact/hooks";
+import { useCallback } from "preact/hooks";
 import { Checkbox, CheckboxChecked } from "@/assets";
 import { LOCK_COMBO } from "@common/css";
 
@@ -11,7 +11,7 @@ interface ICheckboxProps {
 	/**
 	 * Уникальный ID флажка
 	 */
-	id?: string;
+	id: string;
 
 	/**
 	 * Обработчик снятия/установки флажка
@@ -82,29 +82,14 @@ const S = toStyleCombiner({
 });
 
 /**
- * @returns "Уникальный" ID для флажка
- */
-function generateID() {
-	return `ch${Date.now()}`;
-}
-
-/**
  * @param props Свойства галочки
  * @returns Элемент галочки с текстом
  */
 export function CheckboxRow(props: ICheckboxProps) {
-	const { text, onChange } = props;
+	const { text, id, onChange } = props;
 
 	const isChecked = props.checked ?? false;
 	const isDisabled = props.disabled ?? false;
-
-	const [id, setID] = useState(props.id);
-
-	useEffect(() => {
-		if (id != null) return;
-
-		setID(generateID());
-	}, [id]);
 
 	const onClick = () => {
 		if (isDisabled) return;


### PR DESCRIPTION
Данный PR исправляет баг, из-за которого для каждого из флажков создавался одинаковый ID, что приводило к тому, что скринридеры неправильно читали неправильную надпись для всех флажков.

Исправление весьма простое - не создавать никаких уникальных ID, а заполнять их вручную, основываясь на самом ID списка. Такое исправление также избавляет нас от нужды в странных эффектах и хранении ID как отдельного состояния.