### PR TITLE
fix(a11y): использование img для аватарок

### DIFF
--- a/src/components/vk/InfoBlock.tsx
+++ b/src/components/vk/InfoBlock.tsx
@@ -2,6 +2,7 @@ import { h, ComponentChild } from "preact";
 import { GENERIC_CAMERA_ICON } from "@common/consts";
 import { toStyleCombiner } from "@utils/fashion";
 import { CLEARFIX, POINTER_LOCKED } from "@common/css";
+import { useTranslation } from "@utils/hooks";
 
 /**
  * Представляет собой опции блока информации об объекте
@@ -59,8 +60,7 @@ const S = toStyleCombiner({
 		height: "42px",
 		borderRadius: "100%",
 		overflow: "hidden",
-		backgroundSize: "cover",
-		backgroundPosition: "50%",
+		objectFit: "cover",
 	},
 
 	infoText: {
@@ -83,13 +83,15 @@ const NO_CLICK = (e: MouseEvent) => {
  * @returns Блок информации о паблике, группе или пользователе
  */
 export function InfoBlock(props: IInfoBlockProps) {
-	const { displayName, avatarUrl, link, infoChildren } = props;
+	const translation = useTranslation("infoBlock");
 
-	const avatarStyle = {
-		backgroundImage: `url("${avatarUrl ?? GENERIC_CAMERA_ICON}")`,
-	};
+	const { displayName, link, infoChildren } = props;
 
 	const disabled = props.disabled ?? false;
+
+	const avatarUrl = props.avatarUrl ?? GENERIC_CAMERA_ICON;
+
+	const avatarAlt = translation.avatarAlt.replace("{}", displayName);
 
 	const onClick = disabled ? NO_CLICK : undefined;
 
@@ -97,9 +99,10 @@ export function InfoBlock(props: IInfoBlockProps) {
 		<div className={S("infoBlock", "clearfix")}>
 			<a className={S("leftFloat", "locked", disabled)}
 				href={link} onClick={onClick}>
-				<div
+				<img
 					className={S("targetAvatar")}
-					style={avatarStyle}
+					src={avatarUrl}
+					alt={avatarAlt}
 				/>
 			</a>
 			<div className={S("leftFloat", "targetInfo")}>

--- a/src/i18n/_translation.d.ts
+++ b/src/i18n/_translation.d.ts
@@ -95,6 +95,16 @@ declare interface ITranslation {
 	};
 
 	/**
+	 * Текст для блока информации о пользователе/сообществе
+	 */
+	infoBlock: {
+		/**
+		 * Альтернативный текст для аватарки
+		 */
+		avatarAlt: string;
+	};
+
+	/**
 	 * Текст подписки
 	 */
 	followStatus: {

--- a/src/i18n/en-US.yml
+++ b/src/i18n/en-US.yml
@@ -57,6 +57,9 @@ lists:
 listCreation:
   highlightTooltip: "{} is here"
 
+infoBlock:
+  avatarAlt: "{}'s avatar"
+
 errorBoundary:
   text: "Unfortunately, due to a bug in our code, this window has failed to render :(\n\nPlease, try another browser and !!report to extension developer!! if that won't solve the problem."
 

--- a/src/i18n/ru-RU.yml
+++ b/src/i18n/ru-RU.yml
@@ -54,6 +54,9 @@ lists:
 listCreation:
   highlightTooltip: "{} здесь"
 
+infoBlock:
+  avatarAlt: "Аватарка {}"
+
 privateWarning:
   profile: "Это закрытый профиль. Вам необходимо добавить пользователя в друзья, чтобы его новости отображались в выбранных вами списках."
   group:


### PR DESCRIPTION
Использование div с `backgroundUrl` вместо обычного `img` может создавать проблемы с доступностью. `backgroundPosition` и `backgroundSize` можно вполне заменить `objectPosition` и `objectFit`.

Данный PR исправляет подобное использование с аватаркой сообщества или пользователя.