### PR TITLE
refactor: разделение хуков

### DIFF
--- a/src/utils/hooks/contextHooks.ts
+++ b/src/utils/hooks/contextHooks.ts
@@ -1,6 +1,6 @@
-import { useState, useCallback, useContext } from "preact/hooks";
-import { BoxContext } from "@components/contexts/BoxContext";
+import { useContext } from "preact/hooks";
 import { TargetContext } from "@components/contexts/TargetContext";
+import { BoxContext } from "@components/contexts/BoxContext";
 import { TranslationContext } from "@components/contexts/TranslationContext";
 
 /**
@@ -52,34 +52,4 @@ export function useTranslation<Key extends keyof ITranslation>(tree: Key) {
 	const translation = useTranslations();
 
 	return translation[tree];
-}
-
-/**
- * @returns Функция для принудительного обновления компонента
- */
-export function useForceUpdate() {
-	const [, setTick] = useState(0);
-
-	return useCallback(() => {
-		setTick((tick) => tick + 1);
-	}, []);
-}
-
-/**
- * Хук для использования обработчика события и автоматической отмены
- * действия по умолчанию для элемента
- *
- * @param callback Обработчик события
- * @returns Обработчик, который можно использовать для событий
- */
-export function usePreventedCallback<E extends Event>(
-	callback?: ((event: E) => void) | null,
-) {
-	return useCallback((event: E) => {
-		event.preventDefault();
-
-		callback?.(event);
-
-		return false;
-	}, [callback]);
 }

--- a/src/utils/hooks/index.ts
+++ b/src/utils/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./contextHooks";
+export * from "./utilityHooks";

--- a/src/utils/hooks/utilityHooks.ts
+++ b/src/utils/hooks/utilityHooks.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback } from "preact/hooks";
+
+/**
+ * @returns Функция для принудительного обновления компонента
+ */
+export function useForceUpdate() {
+	const [, setTick] = useState(0);
+
+	return useCallback(() => {
+		setTick((tick) => tick + 1);
+	}, []);
+}
+
+/**
+ * Хук для использования обработчика события и автоматической отмены
+ * действия по умолчанию для элемента
+ *
+ * @param callback Обработчик события
+ * @returns Обработчик, который можно использовать для событий
+ */
+export function usePreventedCallback<E extends Event>(
+	callback?: ((event: E) => void) | null,
+) {
+	return useCallback((event: E) => {
+		event.preventDefault();
+
+		callback?.(event);
+
+		return false;
+	}, [callback]);
+}


### PR DESCRIPTION
Чтобы не переполнять файлы импортами и самим хуками в будущем, имеет смысл разделить хуки по отдельным файлом, в отдельной папке, создав index файл, который экспортирует их все.