### PR TITLE
feat: замена showTooltip / showTitle на хуки

### DIFF
--- a/src/_globals.ts
+++ b/src/_globals.ts
@@ -698,7 +698,7 @@ declare global {
 		showTitle<Elem extends Element>(
 			element: Elem,
 			text: string,
-			offsets?: (readonly [number, number | undefined]),
+			offsets?: VK.TooltipShift,
 			opts?: Partial<VK.ITooltipOptions<Elem>>,
 		): void;
 

--- a/src/components/lists/AddListButton.tsx
+++ b/src/components/lists/AddListButton.tsx
@@ -1,7 +1,6 @@
-import { usePreventedCallback } from "@utils/hooks";
+import { usePreventedCallback, useTitle } from "@utils/hooks";
 import { h } from "preact";
-import { getWindow } from "@utils/window";
-import { useRef, useContext, useCallback } from "preact/hooks";
+import { useContext } from "preact/hooks";
 import { TranslationContext } from "@components/contexts/TranslationContext";
 import { toStyleCombiner } from "@utils/fashion";
 import { LOCK_COMBO } from "@common/css";
@@ -32,6 +31,8 @@ const STYLE = toStyleCombiner({
 // eslint-disable-next-line @typescript-eslint/no-magic-numbers
 const TOOLTIP_OFFSETS = [-10, 8] as const;
 
+const CENTER_TOOLTIP = { center: true };
+
 /**
  * Представляет собой свойства ссылки
  */
@@ -52,30 +53,22 @@ export interface IAddListButtonProps {
  * @returns Ссылка на добавление нового списка
  */
 export function AddListButton({ onClick, ...props }: IAddListButtonProps) {
-	const button = useRef<HTMLAnchorElement>();
-
 	const disabled = props.disabled ?? false;
 
 	const onLinkClick = usePreventedCallback(disabled ? null : onClick);
 
 	const { addListButton: translation } = useContext(TranslationContext);
 
-	const showTooltip = useCallback(() => {
-		if (button.current == null) return;
-
-		getWindow().showTitle(
-			button.current,
-			translation.tooltip,
-			TOOLTIP_OFFSETS,
-			{ center: true },
-		);
-	}, [translation.tooltip]);
+	const showTooltip = useTitle(
+		translation.tooltip,
+		TOOLTIP_OFFSETS,
+		CENTER_TOOLTIP,
+	);
 
 	return (
 		<a
 			onClick={onLinkClick}
 			onMouseOver={showTooltip}
-			ref={button}
 			className={STYLE("button", "locked", disabled)}
 			children={translation.text}
 		/>

--- a/src/components/lists/EditListButton.tsx
+++ b/src/components/lists/EditListButton.tsx
@@ -1,10 +1,9 @@
 import { h } from "preact";
-import { useTarget, useTranslations } from "@utils/hooks";
+import { useTarget, useTranslations, useTitle } from "@utils/hooks";
 import { toClassName } from "@utils/fashion";
 import { EditPen } from "@/assets";
-import { useCallback, useRef, useMemo } from "preact/hooks";
+import { useCallback, useMemo } from "preact/hooks";
 import { editList } from "@vk/helpers/newsfeed";
-import { getWindow } from "@utils/window";
 import { IList } from "@vk/api/lists";
 
 /**
@@ -39,9 +38,8 @@ export function EditListButton({ list }: IEditListButtonProps) {
 	const translation = useTranslations();
 	const { text, icon } = translation.editListButton;
 	const target = useTarget();
-	const buttonRef = useRef<HTMLButtonElement>();
-
 	const label = useMemo(() => text.replace("{}", list.name), [text, list]);
+	const showTooltip = useTitle(label);
 
 	const onClick = useCallback(() => {
 		if (target == null) return;
@@ -49,21 +47,12 @@ export function EditListButton({ list }: IEditListButtonProps) {
 		editList(list.id, target, translation, list.isSelected());
 	}, [list, target, translation]);
 
-	const onMouseOver = useCallback(() => {
-		const { current: button } = buttonRef;
-
-		if (button == null) return;
-
-		getWindow().showTitle(button, label);
-	}, [buttonRef, label]);
-
 	return (
 		<button
 			aria-label={label}
 			className={EDIT_BUTTON_CLASS}
 			onClick={onClick}
-			onMouseOver={onMouseOver}
-			ref={buttonRef}
+			onMouseOver={showTooltip}
 			children={<img src={EditPen.dataURL} alt={icon} />}
 		/>
 	);

--- a/src/components/vk/Hint.tsx
+++ b/src/components/vk/Hint.tsx
@@ -1,7 +1,6 @@
-import { h, createRef } from "preact";
-import { useCallback } from "preact/hooks";
-import { getWindow } from "@utils/window";
-// import { TooltipParent } from "@common/types";
+import { h } from "preact";
+import { useMemo } from "preact/hooks";
+import { useTooltip } from "@utils/hooks";
 
 /**
  * Представляет собой опции элемента подсказки
@@ -37,29 +36,22 @@ const HINT_TOOLTIP_SLIDE = 10;
  * @returns Элемент подсказки
  */
 export function Hint({ style, className, hintOptions, text }: IHintProps) {
-	const hintRef = createRef<HTMLSpanElement>();
+	const tooltipOptions = useMemo(() => ({
+		text,
+		dir: VK.TooltipDirection.Auto,
+		center: true,
+		className,
+		shift: HINT_TOOLTIP_SHIFT,
+		slide: HINT_TOOLTIP_SLIDE,
+		...hintOptions,
+	}), [className, hintOptions, text]);
 
-	const showTooltip = useCallback(() => {
-		const { current } = hintRef;
-
-		if (current == null) return;
-
-		getWindow().showTooltip(current, {
-			text,
-			dir: VK.TooltipDirection.Auto,
-			center: true,
-			className,
-			shift: HINT_TOOLTIP_SHIFT,
-			slide: HINT_TOOLTIP_SLIDE,
-			...hintOptions,
-		});
-	}, [hintOptions, className, hintRef, text]);
+	const showTooltip = useTooltip(tooltipOptions);
 
 	return (
 		<span
 			className="hint_icon"
 			style={style}
-			ref={hintRef}
 			onMouseOver={showTooltip}
 		/>
 	);

--- a/src/utils/hooks/index.ts
+++ b/src/utils/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./contextHooks";
 export * from "./utilityHooks";
+export * from "./vkHooks";

--- a/src/utils/hooks/vkHooks.ts
+++ b/src/utils/hooks/vkHooks.ts
@@ -1,0 +1,109 @@
+import { useState, useCallback, useEffect, useMemo } from "preact/hooks";
+import { getWindow } from "@utils/window";
+
+/**
+ * Представляет собой объект подсказки с методом уничтожения
+ *
+ * Из-за необходимости объекта подсказки знать тип элемента и опций,
+ * создаём тип, имеющий только необходимый нам метод — `destroy()`.
+ */
+interface ITooltipLike {
+	/**
+	 * Функция уничтожения подсказки
+	 */
+	destroy(): void;
+}
+
+/**
+ * Создаёт функцию, которую можно использовать в качестве обработчика
+ * события `onMouseOver` у элемента, для которого требуется отобразить
+ * подсказку с переданными опциями
+ *
+ * Данный хук следует использовать в качестве замены стандартному вызову
+ * `Window#showTooltip`, т.к. при уничтожении элемента, для которого
+ * отображается подсказка, сама подсказка останется в дереве.
+ *
+ * Для часто пересоздаваемых элементов это может привести к большой утечке
+ * памяти, ведь не только элемент, но и объект, хранящий уничтоженный
+ * элемент, элемент подсказки, а также её опции никуда не девается (*уточ.*).
+ *
+ * @param opts Опции для подсказки
+ *
+ * @returns Функция-обработчик события `onMouseOver`
+ */
+export function useTooltip(opts?: Partial<VK.ITooltipOptions<Element>>) {
+	const [tooltipRef] = useState<{ current?: ITooltipLike }>({});
+
+	const destroyTooltip = useCallback(() => {
+		tooltipRef.current?.destroy();
+	}, [tooltipRef]);
+
+	const setTooltip = useCallback((tt: ITooltipLike) => {
+		destroyTooltip();
+
+		tooltipRef.current = tt;
+	}, [destroyTooltip, tooltipRef]);
+
+	useEffect(() => destroyTooltip, [destroyTooltip]);
+
+	// Мы не убираем обработчик события init у подсказки в опциях,
+	// поэтому нам нужно предусмотреть тот случай, когда обработчик
+	// задан в переданных опциях, иначе мы перезапишем его и он не
+	// будет работать.
+	//
+	// Для этого смотрим, задан ли обработчик и если так, то создаём
+	// функцию, которая вызовет сначала его, а потом наш метод установки
+	// подсказки. Если обработчика нет — вызываем установку напрямую.
+	const tooltipOptions = useMemo(() => ({
+		...opts,
+		init: opts?.init != null
+			? (tt: ITooltipLike) => {
+				opts?.init?.(tt as never);
+
+				setTooltip(tt);
+			}
+			: setTooltip,
+	}), [opts, setTooltip]);
+
+	return useCallback((e: MouseEvent) => {
+		getWindow().showTooltip(e.currentTarget as Element, tooltipOptions);
+	}, [tooltipOptions]);
+}
+
+/**
+ * Создаёт функцию, которую можно использовать в качестве обработчика
+ * события `onMouseOver` у элемента, для которого требуется отображать
+ * переданное содержимое подсказки
+ *
+ * @see useTooltip За дополнительной информацией, почему следует использовать
+ * этот хук в качестве замены прямого вызова `Window#showTitle`
+ *
+ * @param titleContents Содержимое подсказки
+ * @param shift Отступы подсказки
+ * @param opts Опции для подсказки
+ *
+ * @see Window#showTitle За дополнительной информацией о параметрах
+ *
+ * @returns Фукнция-обработчик события `onMouseOver`
+ */
+export function useTitle(
+	titleContents: string,
+	shift?: VK.TooltipShift,
+	opts?: Partial<VK.ITooltipOptions<Element>>,
+) {
+	// Этот код точно повторяет то, как работает showTitle.
+	//
+	// Если коротко: title это обычная подсказка с опцией black;
+	// у функции showTitle есть несколько упрощающих аргументов.
+	//
+	// Чтобы не создавать каждый раз новый объект и приводить к
+	// обнулению прошлого обработчика, используем useMemo
+	const $opts = useMemo(() => ({
+		text: titleContents,
+		black: true,
+		shift,
+		...opts,
+	}), [opts, shift, titleContents]);
+
+	return useTooltip($opts);
+}


### PR DESCRIPTION
Прямое использование функций `showTootlip` и `showTitle` может привести к потенциальным утечкам памяти, так как элементы подсказки, созданные вызовом этих методов напрямую привязываются к элементам, для которых они были созданы.

Чтобы упростить рефакторинг и не повторять один и тот же код, данный PR добавляет два хука, которые возвращают простую функцию-обработчик для отображения подсказки. При использовании хука автоматически подкрепляется эффект, который при сбросе уничтожает подсказку.

Это также избавляет от нужды использовать рефы на компоненты с подсказками, отныне будет достаточно просто прикрепить функцию, которую вернул хук в качестве обработчика события `onMouseEnter`.

Этот PR также заменяет ранее использование глобальных функций `showTooltip` и `showTitle` на добавленные хуки.