### PR TITLE
feat: добавлен компонент LinkButton

### DIFF
--- a/src/components/box/NotificationsToggle.tsx
+++ b/src/components/box/NotificationsToggle.tsx
@@ -3,6 +3,7 @@ import { useTarget, useTranslation } from "@utils/hooks";
 import { useEffect } from "preact/hooks";
 import { ProgressIndicator, dotsSize } from "@components/vk/ProgressIndicator";
 import { c, toClassName } from "@utils/fashion";
+import { LinkButton } from "@components/vk/LinkButton";
 
 const INDICATOR_STYLES = toClassName("inline", {
 	display: "inline-block",
@@ -39,9 +40,9 @@ export function NotificationsToggle() {
 		: null;
 
 	return (
-		<a onClick={toggle}>
+		<LinkButton onClick={toggle}>
 			{translation[Number(notifications.isToggled)]}
 			{progressIndicator}
-		</a>
+		</LinkButton>
 	);
 }

--- a/src/components/vk/LinkButton.tsx
+++ b/src/components/vk/LinkButton.tsx
@@ -1,0 +1,24 @@
+import { h, JSX } from "preact";
+import { c, toClassName } from "@utils/fashion";
+
+const LINK_BUTTON_CLASS = toClassName("linkButton", {
+	background: "none",
+	border: "none",
+	font: "inherit",
+	color: "#2a5885",
+	cursor: "pointer",
+	padding: "inherit",
+
+	"&:hover, &:focus": { textDecoration: "underline" },
+});
+
+/**
+ * @param props Обычные свойства кнопки
+ *
+ * @returns Кнопку стилизованную под ссылку
+ */
+export function LinkButton(props: JSX.IntrinsicElements["button"]) {
+	const { className } = props;
+
+	return <button {...props} className={c(LINK_BUTTON_CLASS, className)} />;
+}


### PR DESCRIPTION
Представляет собой кнопку, которая выглядит как ссылка. В то время как ссылки менее доступны и требуют странных хаков, типа отмены стандартного события `onClick`, задача кнопок быть просто кликабельными и это то, что нам надо, но большие кнопки выглядят не к месту, отсюда стилизация под ссылки.